### PR TITLE
Replace Recipe.by_duration with class method

### DIFF
--- a/.recipes/query_for_recipe_by_duration.md
+++ b/.recipes/query_for_recipe_by_duration.md
@@ -5,16 +5,16 @@
 class Recipe < ApplicationRecord
   has_many :steps
 
-  scope :by_duration, -> {
+  scope :quick, -> {
+    joins(:steps).group(:id).having("SUM(duration) <= ?", 15.minutes.iso8601)
+  }
+
+  def self.by_duration
     joins(:steps)
       .group(:name)
       .order("SUM(steps.duration) ASC")
       .sum(:duration)
-  }
-
-  scope :quick, -> {
-    joins(:steps).group(:id).having("SUM(duration) <= ?", 15.minutes.iso8601)
-  }
+  end  
 end
 ```
 

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -23,13 +23,6 @@ class Recipe < ApplicationRecord
     joins(:rich_text_description).where("body LIKE ?", "%#{string}%")
   }
 
-  scope :by_duration, -> {
-    joins(:steps)
-      .group(:name)
-      .order("SUM(steps.duration) ASC")
-      .sum(:duration)
-  }
-
   scope :quick, -> {
     joins(:steps).group(:id).having("SUM(duration) <= ?", 15.minutes.iso8601)
   }
@@ -47,6 +40,13 @@ class Recipe < ApplicationRecord
       .order(:name)
       .distinct
   }
+
+  def self.by_duration
+    joins(:steps)
+      .group(:name)
+      .order("SUM(steps.duration) ASC")
+      .sum(:duration)
+  end
 
   def self.per_chef
     Chef


### PR DESCRIPTION
Since Recipe.by_duration does not return an instance of `ActiveRecord::Relation`, we should convert this into a class method.

Issues
------
- Closes #21