### PR TITLE
Index name on chefs table

### DIFF
--- a/app/models/chef.rb
+++ b/app/models/chef.rb
@@ -6,6 +6,9 @@ class Chef < ApplicationRecord
   has_one :first_recipe, -> { order(created_at: :asc) }, class_name: "Recipe"
   has_one :latest_recipe, class_name: "Recipe"
 
+  validates :name, presence: true
+  validates :name, uniqueness: true
+
   scope :with_unhealthy_recipes, -> {
     joins(:recipes)
       .where(recipes: Recipe.unhealthy)

--- a/db/migrate/20220403113559_add_name_index_to_chefs.rb
+++ b/db/migrate/20220403113559_add_name_index_to_chefs.rb
@@ -1,0 +1,6 @@
+class AddNameIndexToChefs < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :chefs, :name, false
+    add_index :chefs, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_26_174851) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_03_113559) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,9 +53,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_26_174851) do
   end
 
   create_table "chefs", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_chefs_on_name", unique: true
   end
 
   create_table "ingredients", force: :cascade do |t|

--- a/test/models/chef_test.rb
+++ b/test/models/chef_test.rb
@@ -2,13 +2,13 @@ require "test_helper"
 
 class ChefTest < ActiveSupport::TestCase
   test "should be valid" do
-    chef = Chef.new
+    chef = Chef.new(name: "Name")
 
     assert chef.valid?
   end
 
   test "association with recipe" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
 
     assert_difference("chef.recipes.count", 1) do
       chef.recipes.create!(servings: 1)
@@ -17,6 +17,19 @@ class ChefTest < ActiveSupport::TestCase
     assert_difference("chef.recipes.count", -1) do
       chef.destroy!
     end
+  end
+
+  test "should have name" do
+    chef = Chef.new
+
+    assert_not chef.valid?
+  end
+
+  test "name should be unique" do
+    Chef.create!(name: "Name")
+    chef = Chef.new(name: "Name")
+
+    assert_not chef.valid?
   end
 
   test "#unhealthy_recipes" do
@@ -37,7 +50,7 @@ class ChefTest < ActiveSupport::TestCase
   end
 
   test "#quick_recipes" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     chef.recipes.create!(
       name: "Quick",
       servings: 1,
@@ -75,7 +88,7 @@ class ChefTest < ActiveSupport::TestCase
   end
 
   test ".first_recipe" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     chef.recipes.create!(name: "Latest Recipe", servings: 1, created_at: 1.day.ago)
     chef.recipes.create!(name: "First Recipe", servings: 1, created_at: 1.week.ago)
 
@@ -83,7 +96,7 @@ class ChefTest < ActiveSupport::TestCase
   end
 
   test ".latest_recipe" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     chef.recipes.create!(name: "Latest Recipe", servings: 1, created_at: 1.day.ago)
     chef.recipes.create!(name: "First Recipe", servings: 1, created_at: 1.week.ago)
 

--- a/test/models/ingredient_test.rb
+++ b/test/models/ingredient_test.rb
@@ -23,7 +23,7 @@ class IngredientTest < ActiveSupport::TestCase
 
   test "#measurements" do
     ingredient = Ingredient.create!
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     recipe = chef.recipes.create!(servings: 1)
 
     assert_difference("Measurement.count", 1) do
@@ -36,7 +36,7 @@ class IngredientTest < ActiveSupport::TestCase
   end
 
   test ".popular" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     sugar = Ingredient.create!(name: "Sugar")
     egg = Ingredient.create!(name: "Egg")
     flour = Ingredient.create!(name: "Flour")

--- a/test/models/measurement_test.rb
+++ b/test/models/measurement_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class MeasurementTest < ActiveSupport::TestCase
   test "should be valid" do
     ingredient = Ingredient.create!
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     recipe = chef.recipes.create!(servings: 1)
     measurement = ingredient.measurements.new(recipe: recipe)
 

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class RecipeTest < ActiveSupport::TestCase
   test "should be valid" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     recipe = chef.recipes.new(servings: 1)
 
     assert recipe.valid?
@@ -10,7 +10,7 @@ class RecipeTest < ActiveSupport::TestCase
 
   test "#ingredients" do
     ingredient = Ingredient.create!
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     recipe = chef.recipes.create!(servings: 1)
     ingredient.measurements.create!(recipe: recipe)
 
@@ -19,7 +19,7 @@ class RecipeTest < ActiveSupport::TestCase
 
   test "#measurements" do
     ingredient = Ingredient.create!
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     recipe = chef.recipes.create!(servings: 1)
 
     assert_difference("Measurement.count", 1) do
@@ -32,7 +32,7 @@ class RecipeTest < ActiveSupport::TestCase
   end
 
   test "#description" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
 
     assert_difference("ActionText::RichText.count", 1) do
       chef.recipes.create!(description: "some description", servings: 1)
@@ -40,8 +40,8 @@ class RecipeTest < ActiveSupport::TestCase
   end
 
   test ".latest_per_chef" do
-    chef_one = Chef.create!
-    chef_two = Chef.create!
+    chef_one = Chef.create!(name: "Chef One")
+    chef_two = Chef.create!(name: "Chef Two")
     chef_one.recipes.create!(name: "Latest Recipe For Chef One", servings: 1, created_at: 1.hour.ago)
     chef_one.recipes.create!(name: "First Recipe For Chef One", servings: 1, created_at: 1.day.ago)
     chef_two.recipes.create!(name: "Latest Recipe For Chef Two", servings: 1, created_at: 1.hour.ago)
@@ -51,8 +51,8 @@ class RecipeTest < ActiveSupport::TestCase
   end
 
   test ".first_per_chef" do
-    chef_one = Chef.create!
-    chef_two = Chef.create!
+    chef_one = Chef.create!(name: "Chef One")
+    chef_two = Chef.create!(name: "Chef Two")
     chef_one.recipes.create!(name: "Latest Recipe For Chef One", servings: 1, created_at: 1.hour.ago)
     chef_one.recipes.create!(name: "First Recipe For Chef One", servings: 1, created_at: 1.day.ago)
     chef_two.recipes.create!(name: "Latest Recipe For Chef Two", servings: 1, created_at: 1.hour.ago)
@@ -74,7 +74,7 @@ class RecipeTest < ActiveSupport::TestCase
   end
 
   test ".with_description" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     chef.recipes.create!(id: 1, servings: 1, description: "he is here")
     chef.recipes.create!(id: 2, servings: 1, description: "hello world")
     chef.recipes.create!(id: 3, servings: 1)
@@ -85,7 +85,7 @@ class RecipeTest < ActiveSupport::TestCase
   end
 
   test ".by_duration" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     chef.recipes.create!(
       name: "Recipe One",
       servings: 1,
@@ -118,7 +118,7 @@ class RecipeTest < ActiveSupport::TestCase
   end
 
   test ".quick" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     chef.recipes.create!(
       name: "Quick",
       servings: 1,
@@ -156,7 +156,7 @@ class RecipeTest < ActiveSupport::TestCase
   end
 
   test ".unhealthy" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     sugar = Ingredient.create!(name: "Sugar")
     egg = Ingredient.create!(name: "Egg")
     recipe_one = chef.recipes.create!(name: "Unhealthy Recipe", servings: 2)
@@ -171,7 +171,7 @@ class RecipeTest < ActiveSupport::TestCase
   end
 
   test ".with_ingredients" do
-    chef = Chef.create!
+    chef = Chef.create!(name: "Name")
     sugar = Ingredient.create!(name: "Sugar")
     egg = Ingredient.create!(name: "Egg")
     flour = Ingredient.create!(name: "Flour")


### PR DESCRIPTION
There are several scopes that query against the name column on the chefs table. Adding a unique index ensures the queries will be processed quickly, and also ensures that grouping results by name will work as expected.

Issues
------
- Closes #24