### PR TITLE
Update tests to account for order

### DIFF
--- a/test/models/ingredient_test.rb
+++ b/test/models/ingredient_test.rb
@@ -51,5 +51,6 @@ class IngredientTest < ActiveSupport::TestCase
     recipe_four.measurements.create!(ingredient: egg)
 
     assert_equal({"egg" => 2, "sugar" => 2, "flour" => 1}, Ingredient.popular)
+    assert_equal(["egg", 2], Ingredient.popular.first)
   end
 end

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -88,6 +88,7 @@ class RecipeTest < ActiveSupport::TestCase
     chef_three.recipes.create!(name: "Recipe Four", servings: 1)
 
     assert_equal({"Bob" => 2, "Ali" => 1, "Alice" => 1}, Recipe.per_chef)
+    assert_equal(["Bob", 2], Recipe.per_chef.first)
   end
 
   test ".with_description_containing" do
@@ -132,6 +133,7 @@ class RecipeTest < ActiveSupport::TestCase
     )
 
     assert_equal({"Recipe Two" => 300, "Recipe One" => 1500}, Recipe.by_duration)
+    assert_equal(["Recipe Two", 300], Recipe.by_duration.first)
   end
 
   test ".quick" do


### PR DESCRIPTION
Update tests to account for the order in which results are returned. The original tests did not accurately account for this, because they were comparing hashes. This could result in false positives.

Example:

```ruby
{foo: :bar, baz: :biz} == {baz: :biz, foo: :bar}
# => true
```

Issues
------
- Closes #30