### PR TITLE
Require a recipe to have a name via a database constraint

### DIFF
--- a/db/migrate/20220422094609_add_not_null_constraint_on_recipe_name.rb
+++ b/db/migrate/20220422094609_add_not_null_constraint_on_recipe_name.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintOnRecipeName < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :recipes, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_04_150111) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_22_094609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,7 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_04_150111) do
   end
 
   create_table "recipes", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.bigint "chef_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
A recipe should always have a name, so a database constraint was added. This is
especially true since we have a unique index on the recipe name and chef_id.

Issues
------
- Closes #34