### PR TITLE
Fix grouping on Recipe.by_duration

### DIFF
--- a/.recipes/query_for_recipe_by_duration.md
+++ b/.recipes/query_for_recipe_by_duration.md
@@ -11,7 +11,7 @@ class Recipe < ApplicationRecord
 
   def self.by_duration
     joins(:steps)
-      .group(:name)
+      .group(:name, :chef_id)
       .order("SUM(steps.duration) ASC")
       .sum(:duration)
   end  

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -54,7 +54,7 @@ class Recipe < ApplicationRecord
 
   def self.by_duration
     joins(:steps)
-      .group(:name)
+      .group(:name, :chef_id)
       .order("SUM(steps.duration) ASC")
       .sum(:duration)
   end

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -132,8 +132,8 @@ class RecipeTest < ActiveSupport::TestCase
       ]
     )
 
-    assert_equal({"Recipe Two" => 300, "Recipe One" => 1500}, Recipe.by_duration)
-    assert_equal(["Recipe Two", 300], Recipe.by_duration.first)
+    assert_equal({["Recipe Two", chef.id] => 300, ["Recipe One", chef.id] => 1500}, Recipe.by_duration)
+    assert_equal([["Recipe Two", chef.id], 300], Recipe.by_duration.first)
   end
 
   test ".quick" do


### PR DESCRIPTION
When grouping recipes by duration, we need to group them by name and the chef'd
ID, since multiple recipes can have the same name, but a chef cannot have
mutliple recipes with the same name.

Issues
------
Closes #36