### PR TITLE
Sanitize LIKE query

### DIFF
--- a/.recipes/query_recipes_by_action_text_body.md
+++ b/.recipes/query_recipes_by_action_text_body.md
@@ -6,7 +6,11 @@ class Recipe < ApplicationRecord
   has_rich_text :description
 
   def self.with_description_containing(string)
-    joins(:rich_text_description).where("body LIKE ?", "%#{string}%")
+    joins(:rich_text_description)
+      .where(
+        "body LIKE ?",
+        "%" + Recipe.sanitize_sql_like(string) + "%"
+      )
   end
 end
 ```

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -22,7 +22,11 @@ class Recipe < ApplicationRecord
   end
 
   def self.with_description_containing(string)
-    joins(:rich_text_description).where("body LIKE ?", "%#{string}%")
+    joins(:rich_text_description)
+      .where(
+        "body LIKE ?",
+        "%" + Recipe.sanitize_sql_like(string) + "%"
+      )
   end
 
   def self.quick

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -96,10 +96,13 @@ class RecipeTest < ActiveSupport::TestCase
     chef.recipes.create!(name: "Recipe One", servings: 1, description: "he is here")
     chef.recipes.create!(name: "Recipe Two", servings: 1, description: "hello world")
     chef.recipes.create!(name: "Recipe Three", servings: 1)
+    chef.recipes.create!(name: "Recipe Four", servings: 1, description: "Uses 100% grass fed beef")
+    chef.recipes.create!(name: "Recipe Five", servings: 1, description: "100 5 star reviews and counting")
 
-    assert_equal ["Recipe One", "Recipe Two"], Recipe.with_description_containing("").map(&:name)
+    assert_equal ["Recipe One", "Recipe Two", "Recipe Four", "Recipe Five"], Recipe.with_description_containing("").map(&:name)
     assert_equal ["Recipe One", "Recipe Two"], Recipe.with_description_containing("he").map(&:name)
     assert_equal ["Recipe Two"], Recipe.with_description_containing("hello").map(&:name)
+    assert_equal ["Recipe Four"], Recipe.with_description_containing("100%").map(&:name)
   end
 
   test ".by_duration" do


### PR DESCRIPTION
When making a like query, we want to first [sanitize the string](https://guides.rubyonrails.org/active_record_querying.html#conditions-that-use-like) to avoid accidental wild card searches.

Issues
------
- Closes #45